### PR TITLE
Add files via upload

### DIFF
--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B01_Starting_Off.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B01_Starting_Off.lua
@@ -1,0 +1,51 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1500
+Opponent's Starting LP: 1400
+Complexity: 1/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1500,0,0)
+Debug.SetPlayerInfo(1,1400,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Extra Deck (yours)
+Debug.AddCard(64599569,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)
+
+--Hand (yours)
+Debug.AddCard(3659803,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(31036355,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--GY (yours)
+Debug.AddCard(26439287,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(7359741,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(7359741,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(70095154,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(70095154,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Monster Zones (opponent's)
+Debug.AddCard(89631142,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Overload Fusion, fusing Cyber Dragon and only one other Machine in your Graveyard to create Chimeratech Overdragon.
+-Activate Creature Swap. You give them Chimeratech Overdragon and they give you Blue-Eyes White Dragon.
+-Enter the Battle Phase.
+-Attack Chimeratech Overdragon with Blue-Eyes White Dragon. (1500/0)
+]]

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B02_Master_The_Dimensions.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B02_Master_The_Dimensions.lua
@@ -1,0 +1,59 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 3000
+Opponent's Starting LP: 3000
+Complexity: 1+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,3000,0,0)
+Debug.SetPlayerInfo(1,3000,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(23557835,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(28279543,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Banished (yours)
+Debug.AddCard(89631142,0,0,LOCATION_REMOVED,0,POS_FACEUP)
+
+--Monster Zones (yours)
+Debug.AddCard(89631142,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(89631142,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(53582587,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(36261276,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+
+--Banished (opponent's)
+Debug.AddCard(89631142,1,1,LOCATION_REMOVED,0,POS_FACEUP)
+
+--Monster Zones (opponent's)
+Debug.AddCard(62180201,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Interdimensional Matter Transporter to remove one of your Blue-Eyes White Dragons from play.
+-Sacrifice the other Blue-Eyes White Dragon to summon Curse of Dragon.
+-Activate Torrential Tribute, which destroys Curse of Dragon and The Wicked Dreadroot.
+-Activate Dimension Fusion, paying 2000 LP to summon all monsters removed from play. (1000/3000) 
+-Summon 2 Blue-Eyes White Dragons in ATK mode, while your opponent summons their Blue-Eyes White Dragon.
+-Enter the Battle Phase.
+-Attack their Blue-Eyes White Dragon with your Blue-Eyes White Dragon (both are destroyed). 
+-Attack them directly with the remaining Blue-Eyes White Dragon. (1000/0)
+]]

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B03_Oh_Jama.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B03_Oh_Jama.lua
@@ -1,0 +1,52 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 100
+Opponent's Starting LP: 9900
+Complexity: 1/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,100,0,0)
+Debug.SetPlayerInfo(1,9900,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(79409334,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(511003009,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(84808313,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(79409334,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(83133491,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(29843091,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(2851070,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(2851070,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Ojama Trio. Your opponent gains 3 Ojama Tokens.
+-Activate Zero Gravity. The tokens switch to ATK mode.
+-Activate Big Evolution Pill, sacrificing Black Stego as Tribute.
+-With the effect of Big Evolution Pill you can summon Ultimate Tyranno without Tribute.
+-Enter the Battle Phase.
+-Attack the 3 tokens with Ultimate Tyranno.
+]]

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B04_Ancient_Kings.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B04_Ancient_Kings.lua
@@ -1,0 +1,56 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 100
+Opponent's Starting LP: 4200
+Complexity: 2+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,100,0,0)
+Debug.SetPlayerInfo(1,4200,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(75390004,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(79870141,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(511003009,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(17375316,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(84808313,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(40374923,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(80161395,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(511003023,0,0,LOCATION_SZONE,3,POS_FACEUP)
+
+--Hand (opponent's)
+Debug.AddCard(40640057,1,1,LOCATION_HAND,0,POS_FACEDOWN)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Big Evolution Pill, sacrificing Mammoth Graveyard.
+-With the effect of Big Evolution Pill you can summon Megazowler without Tribute.
+-Activate Mystik Wok, sacrificing Megazowler to gain 2000 LP by selecting DEF.
+-Activate Confiscation, paying 1000 LP to look at your opponent's hand and discard the only card in it - Kuriboh.
+-Activate Ultimate Offering, paying 500 LP to summon Mad Sword Beast.
+-Activate Ultimate Offering again, paying 500 LP (and using Big Evolution Pill) to summon Ultimate Tyranno.
+-Use Confiscation to make the opponent discard Kuriboh.
+-Enter the Battle Phase.
+-Attack them directly with Mad Sword Beast and Ultimate Tyranno.
+]]

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B05_Dark_Room_of_Nightmare.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B05_Dark_Room_of_Nightmare.lua
@@ -1,0 +1,80 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 4000
+Opponent's Starting LP: 6900
+Complexity: 2+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,4000,0,0)
+Debug.SetPlayerInfo(1,6900,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(511003009,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(41855169,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+local m_3=Debug.AddCard(63259351,0,0,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+local m_4=Debug.AddCard(22056710,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(511000824,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+Debug.AddCard(21219755,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(85562745,0,0,LOCATION_SZONE,1,POS_FACEUP)
+local t_2=Debug.AddCard(54704216,0,0,LOCATION_SZONE,0,POS_FACEUP)
+local t_1=Debug.AddCard(54704216,0,0,LOCATION_SZONE,4,POS_FACEUP)
+
+--Deck (yours)
+Debug.AddCard(511003009,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+local m_1=Debug.AddCard(48229808,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+local m_2=Debug.AddCard(504700015,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's)
+local t_3=Debug.AddCard(54704216,1,1,LOCATION_SZONE,3,POS_FACEUP)
+local t_4=Debug.AddCard(54704216,1,1,LOCATION_SZONE,2,POS_FACEUP)
+
+Debug.ReloadFieldEnd()
+
+--Nightmare Wheel Targets
+Debug.PreSetTarget(t_1,m_1)
+Debug.PreSetTarget(t_2,m_2)
+Debug.PreSetTarget(t_3,m_3)
+Debug.PreSetTarget(t_4,m_4)
+
+--Special Summoned Monsters
+Debug.PreSummon(m_4,SUMMON_TYPE_SPECIAL)
+Debug.PreSummon(m_1,SUMMON_TYPE_SPECIAL)
+
+--Miracle Jurassic Egg Counter
+Debug.PreAddCounter(m_3,0x14,6)
+
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Summon Jowgen the Spiritualist.
+-Use its effect: Discard Ultimate Tyranno (putting another 2 counters on Miracle Jurassic Egg (8 total)) and 
+destroying Vampire Genesis and Horus the Black Flame Dragon LV8 (and the Nightmare Wheels equipped to them).
+-Activate Destruction Ring, destroying Jowgen the Spiritualist to inflict 1000 damage to your LP, and 1300 to theirs (thanks to Dark Room of Nightmare).
+-Tribute Miracle Jurassic Egg to summon Ultimate Tyranno from your deck.
+-Activate Ring of Destruction, destroying Horus the Black Flame Dragon LV6 and the Nightmare Wheel attached to it to inflict 
+2300 damage to your LP and 2600 damage to their LP (thanks to Dark Room of Nightmare).
+-Enter the Battle Phase.
+-Attack their LP directly with Ultimate Tyranno.
+]]
+

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B06_Your_Challenge_1.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B06_Your_Challenge_1.lua
@@ -1,0 +1,57 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 100
+Opponent's Starting LP: 2300
+Complexity: 2/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,100,0,0)
+Debug.SetPlayerInfo(1,2300,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Main Deck (yours)
+Debug.AddCard(40703222,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+
+--Hand (yours)
+Debug.AddCard(79759861,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(79759861,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(48653261,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(99861526,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(63102017,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(40640057,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(83675475,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(61528025,1,1,LOCATION_MZONE,3,POS_FACEUP_DEFENSE,true)
+Debug.AddCard(549481,1,1,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Guard Penalty designating Kuriboh.
+-Switch Kuriboh to DEF mode. Guard Penalty activates, so you draw Multiply.
+-Activate Multiply, sacrificing Kuriboh to summon 5 Kuriboh tokens.
+-Activate Token Feastevil. The 5 tokens are destroyed and your opponent loses 1500 LP.
+-Summon Submarineroid in ATK mode.
+-Enter the Battle Phase.
+-Attack them directly with Submarineroid.
+]]

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B07_Parallel_World_Dweller.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B07_Parallel_World_Dweller.lua
@@ -1,0 +1,61 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1900
+Opponent's Starting LP: 500
+Complexity: 2/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1900,0,0)
+Debug.SetPlayerInfo(1,500,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(17375316,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(70828912,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(19613556,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(79759861,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(68073522,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(73891874,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(30241314,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+
+--Hand (opponent's)
+Debug.AddCard(21593987,1,1,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(97590747,1,1,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(53129443,1,1,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(11224103,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's)
+Debug.AddCard(30606547,1,1,LOCATION_SZONE,2,POS_FACEUP)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Confiscation. You look at their hand and discard Dark Hole.
+-Activate Heavy Storm. Your Macro Cosmos and their The Dark Door are destroyed.
+-Activate Tribute to the Doomed. You discard Soul Absorption to destroy your White-Horned Dragon.
+-Activate Premature Burial. You pay 800 LP to revive White-Horned Dragon.
+-White-Horned Dragon's effect activates. You remove Dark Hole and The Dark Door to increase White-Horned Dragon's ATK by 600.
+-Enter the Battle Phase.
+-Attack Horus the Black Flame Dragon LV6 with White-Horned Dragon.
+]]

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B08_Trial_of_Strength.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B08_Trial_of_Strength.lua
@@ -1,0 +1,52 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1300
+Opponent's Starting LP: 2400
+Complexity: 1/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1300,0,0)
+Debug.SetPlayerInfo(1,2400,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(70828912,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--GY (yours)
+Debug.AddCard(13723605,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Monster Zones (yours)
+Debug.AddCard(504700167,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(93382620,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(97077563,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(511000868,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Call of the Haunted, reviving Man-Eating Treasure Chest.
+-Enter the Battle Phase.
+-Attack Twin-Headed Behemoth with Giant Germ. Giant Germ is destoyed so its burn effect activates.
+-Chain to this with Rope of Life. You discard Premature Burial to revive Giant Germ with 800 extra ATK.
+-Attack Twin-Headed Behemoth with Giant Germ, then attack directly with Man-Eating Treasure Chest.
+]]
+

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B09_Only_a_Miracle.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B09_Only_a_Miracle.lua
@@ -1,0 +1,90 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 100
+Opponent's Starting LP: 1700
+Complexity: 2/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,100,0,0)
+Debug.SetPlayerInfo(1,1700,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(71413901,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(60082869,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+Debug.AddCard(37011715,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(41420027,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+
+--GY (opponent's)
+Debug.AddCard(73891874,1,1,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(504700105,1,1,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(22046459,1,1,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Monster Zones (opponent's)
+local m_1=Debug.AddCard(89631142,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's) partially written by PryQ
+local eq_0=Debug.AddCard(1435851,1,1,LOCATION_SZONE,3,POS_FACEUP)
+local t_1=Debug.AddCard(51452091,1,1,LOCATION_SZONE,2,POS_FACEDOWN)
+t_1:GetActivateEffect():SetCondition(function() return Duel.GetCurrentChain(true)>1 end)
+
+Debug.ReloadFieldEnd()
+
+--Equip Function
+local function Equip(c,target)
+	Debug.PreEquip(c,target)
+	local ctype=c:Type()
+	if ctype&TYPE_EQUIP==0 then
+		local code=EFFECT_CHANGE_TYPE
+		local value=TYPE_EQUIP+TYPE_SPELL
+		if c:IsType(TYPE_TRAP) then
+			code=EFFECT_ADD_TYPE
+			value=TYPE_EQUIP
+		elseif ctype&TYPE_UNION~=0 then
+			value=value+TYPE_UNION
+		elseif ctype&TYPE_TOKEN~=0 then
+			value=value+TYPE_TOKEN
+		end
+		local eff=Effect.CreateEffect(c)
+		eff:SetType(EFFECT_TYPE_SINGLE)
+		eff:SetCode(code)
+		eff:SetValue(value)
+		eff:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		eff:SetReset(RESET_EVENT+0x17e0000)
+		c:RegisterEffect(eff,true)
+	end
+end
+
+--Equipped Cards
+Equip(eq_0,m_1)
+
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Summon Breaker the Magical Warrior.
+-Use Breaker the Magical Warrior's effect to destroy Dragon Treasure.
+-Chain to this with Dust Tornado, targeting their face-down Royal Decree.
+-They will chain Royal Decree.
+-You chain Miraculous Rebirth, selecting White-Horned Dragon.
+-As a result of this chain Dragon Treasure is destoyed.
+-Use White-Horned Dragon's effect, removing Dragon Treasure, Megamorph and Magical Labyrinth to increase its ATK by 900.
+-Enter the Battle Phase.
+-Attack their Blue-Eyes White Dragon with White-Horned Dragon.
+-Attack directly with Breaker the Magical Warrior.
+]]

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B10_Spark_Batteryman.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B10_Spark_Batteryman.lua
@@ -1,0 +1,62 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 600
+Opponent's Starting LP: 600
+Complexity: 2/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,600,0,0)
+Debug.SetPlayerInfo(1,600,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(19733961,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(19733961,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(19733961,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(61181383,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(49398568,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(70095154,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(70278545,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+Debug.AddCard(7076131,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(83968380,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(74157028,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(74157028,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(74157028,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Normal Summon Batteryman C from your hand to the field.
+-Activate Pot of Generosity.
+-Send both copies of Batteryman C to your deck.
+-Activate Next to be Lost.
+-Target Batteryman C to send one Batteryman to your graveyard.
+-Activate Jar of Greed to draw one card from your deck.
+-Activate Battery Charger, then chain it to Serial Spell.
+-Discard Batteryman C from your hand to meet requirement. (100 / 600)
+-Special Summon both copies of Batteryman C to the field. (100 / 600)
+-Attack any Cyber Twin Dragon with Cyber Dragon (He should have 3600 Atk) for game. (100 / 0)
+
+PROTIP: PLEASE MAKE SURE YOU AREN'T DESIGNATING THE SAME BATTERYMAN IN YOUR GRAVEYARD AS A TARGET FOR BOTH SPELL CARDS.
+]]

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B11_Mighty_Knights.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B11_Mighty_Knights.lua
@@ -1,0 +1,58 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1500
+Opponent's Starting LP: 4600
+Complexity: 2+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1500,0,0)
+Debug.SetPlayerInfo(1,4600,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(64752646,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(64306248,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(64306248,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(13944422,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(79759861,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(36354008,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(511003023,0,0,LOCATION_SZONE,2,POS_FACEUP)
+Debug.AddCard(3819470,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(504700126,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(64306248,1,1,LOCATION_MZONE,2,POS_FACEDOWN_DEFENSE,true)
+Debug.AddCard(504700006,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's)
+Debug.AddCard(56120475,1,1,LOCATION_SZONE,2,POS_FACEDOWN)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Summon Fire Princess.
+-Pay 500 LP to activate the effect of Ultimate Offering. You summon Granadora.
+-Pay 500 LP to activate the effect of Ultimate Offering. You summon Skull-Mark Ladybug.
+-Pay 500 LP to activate the effect of Ultimate Offering. You summon your other Skull-Mark Ladybug.
+-Pay 500 LP to activate the effect of Ultimate Offering for the final time. Tribute both Skull-Mark Ladybugs 
+and Granadora to summon Gilford the Lightning.
+-Attack directly with Gilford the Lightning. Your opponent activates Sakuretsu Armor. Chain to this with Seven Tools of the Bandit.
+-Attack directly with Fire Princess.
+]]

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B12_Heros_Lapse.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B12_Heros_Lapse.lua
@@ -1,0 +1,70 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1500
+Opponent's Starting LP: 2100
+Complexity: 4/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1500,0,0)
+Debug.SetPlayerInfo(1,2100,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(75041269,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(71413901,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(40591390,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--GY (yours)
+Debug.AddCard(81866673,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(77608643,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Monster Zones (yours)
+Debug.AddCard(28933734,0,0,LOCATION_MZONE,2,POS_FACEDOWN_DEFENSE,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(511000821,0,0,LOCATION_SZONE,1,POS_FACEUP)
+Debug.AddCard(53046408,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(35787450,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+
+--GY (opponent's)
+Debug.AddCard(21844576,1,1,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(58932615,1,1,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Monster Zones (opponent's)
+Debug.AddCard(25366484,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's)
+Debug.AddCard(79323590,1,1,LOCATION_SZONE,2,POS_FACEUP)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Clock Tower Prison.
+-Activate Eternal Dread.
+-Flip Summon Mask of Darkness.
+-Use its effect to add Eternal Dread to your hand.
+-Use the effect of Cathedral of Nobles to activate Eternal Dread when you set it.
+-Chain to this with Emergency Provisions, sacrificing Cathedral of Nobles and Eternal Dread to gain 2000 LP.
+-Summon Breaker the Magical Warrior.
+-Use its effect to destroy Clock Tower Prison, which activates to summon Destiny Hero - Dreadmaster.
+-Destiny Hero - Dreadmaster's effect activates, destroying Breaker and Mask of Darkness.
+-Use Destiny Hero - Dreadmaster's effect to summon Destiny Hero - Captain Tenacious and Destiny Hero - Dasher.
+-Use Destiny Hero - Dasher's effect, sacrificing Destiny Hero - Captain Tenacious to gain 1000 ATK.
+-Attack Elemental Hero Shining Flare Wingman with Dasher.
+-Attack them directly with Destiny Hero - Dreadmaster.
+]]

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B13_Testing_Your_Skills.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B13_Testing_Your_Skills.lua
@@ -1,0 +1,62 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1500
+Opponent's Starting LP: 2000
+Complexity: 2/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1500,0,0)
+Debug.SetPlayerInfo(1,2000,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(14087893,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(60482781,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(42035044,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(37580756,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(97077563,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(78658564,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(34853266,1,1,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+Debug.AddCard(34853266,1,1,LOCATION_MZONE,1,POS_FACEUP_DEFENSE,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Attack Goblin Attack Force with Mystic Swordsman LV6.
+-Activate Michizure to destroy Tsukuyomi.
+-Activate Call of the Haunted to bring back Mystic Swordsman LV6.
+-Attack with Mystic Swordsman LV6 the second Tsukuyomi.
+-Attack directly with Panther Warrior tributing Mystic Swordsman LV6.
+
+Another Method:
+
+-Activate Book of Moon and select Goblin Attack Force.
+-Enter the Battle Phase.
+-Attack Goblin Attack Force with Mystic Swordsman LV6, the effect will activate 
+(it doesn't matter whether you choose to put the card on top of the deck or not).
+-Attack Tsukuyomi with Panther Warrior, using Mystic Swordsman LV6 as a Tribute.
+-Activate Michizure, selecting the Tsukuyomi you aren't attacking.
+-Activate Call of the Haunted to bring back Mystic Swordsman LV6.
+-Attack directly with Mystic Swordsman LV6.
+]]

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B14_First_Barrier.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B14_First_Barrier.lua
@@ -1,0 +1,52 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1500
+Opponent's Starting LP: 5300
+Complexity: 2/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1500,0,0)
+Debug.SetPlayerInfo(1,5300,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(51632798,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(70828912,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(69196160,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(97687912,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(79759861,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(74677422,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(94119974,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+
+--Monster Zones (opponent's)
+Debug.AddCard(11224103,1,1,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Summon Fusilier Dragon, the Dual-Mode Beast without Tributes.
+-Activate Tribute to the Doomed discarding Fairy Meteor Crush and destroy Fusilier Dragon, the Dual-Mode Beast
+-Activate Premature Burial to revive Fusilier Dragon, the Dual-Mode Beast with it's complete ATK points.
+-Enter to battle Phase.
+-Attack Horus the Black Flame Dragon LV6 with Red-Eyes B. Dragon.
+-Attack directly with Fusilier Dragon, the Dual-Mode Beast and Two-Headed King Rex.
+-Go to Main Phase 2.
+-Activate Thunder Crash destroying your own monsters to inflict 900 points of damage.
+]]

--- a/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B15_Wild_Vigor.lua
+++ b/GX Spirit Caller/1_Beginner/[GX_Spirit_Caller]B15_Wild_Vigor.lua
@@ -1,0 +1,58 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1400
+Opponent's Starting LP: 3400
+Complexity: 3/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1400,0,0)
+Debug.SetPlayerInfo(1,3400,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(46668237,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(51632798,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(70828912,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(68073522,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(79759861,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(61528025,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(87430998,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(9817927,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(56594520,0,0,LOCATION_FZONE,0,POS_FACEUP)
+
+--Monster Zones (opponent's)
+Debug.AddCard(11224103,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Tribute to the Doomed. Discard Fusilier Dragon, the Dual-Mode Beast and destroy Gyaku-Gire Panda.
+-Activate the effect of Green Baboon, Defender of the Forest. Pay 1000 LP to Special Summon him in Attack Position.
+-Normal Summon Banisher of the Light in Attack Position.
+-Activate Soul Absorption.
+-Activate Forest, destroying Gaia Power. It is removed from play by Banisher of the Light, and 
+you regain 500 LP by the effect of Soul Absorption.
+-Activate Premature Burial. Pay 800 LP to Special Summon Fusilier Dragon.
+-Enter the Battle Phase.
+-Attack Horus the Black Flame Dragon LV6 with either Fusilier Dragon or Green Baboon.
+-Attack directly with your other monsters.
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I01_Your_Challenge2.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I01_Your_Challenge2.lua
@@ -1,0 +1,60 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 600
+Opponent's Starting LP: 1900
+Complexity: 4/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,600,0,0)
+Debug.SetPlayerInfo(1,1900,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Main Deck (yours)
+Debug.AddCard(22587018,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(22587018,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(85520851,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+
+--Hand (yours)
+Debug.AddCard(79759861,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(58071123,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(75390004,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(13069066,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(63259351,0,0,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+Debug.AddCard(22587018,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(511003023,0,0,LOCATION_SZONE,2,POS_FACEUP)
+
+--Monster Zones (opponent's)
+Debug.AddCard(23995346,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(23995346,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(12829151,1,1,LOCATION_MZONE,4,POS_FACEUP_ATTACK,true)
+Debug.AddCard(12829151,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Tribute Hydrogeddon to summon Sword Arm of Dragon.
+-Activate Ultimate Offering. You pay 500 LP to Tribute Sword Arm of Dragon to Summon Megazowler.
+-Activate Tribute to the Doomed. Discard Oxygeddon to destroy Megazowler
+-Activate the effect of Miracle Jurassic Egg. Tribute it to Special Summon Super Conductor Tyranno.
+-Enter the Battle Phase.
+-Attack Kanan the Swordmistress with Super Conductor Tyranno.
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I02_Fight_On.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I02_Fight_On.lua
@@ -1,0 +1,94 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 100
+Opponent's Starting LP: 2500
+Complexity: 3/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,100,0,0)
+Debug.SetPlayerInfo(1,2500,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Main Deck (yours)
+Debug.AddCard(63695531,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(22609617,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(41230939,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+
+--Hand (yours)
+Debug.AddCard(504700142,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(48305365,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(97687912,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--GY (yours)
+Debug.AddCard(511000868,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(38699854,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+Debug.AddCard(14087893,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(504700114,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+local m_1=Debug.AddCard(20277860,1,1,LOCATION_MZONE,3,POS_FACEUP_DEFENSE,true)
+Debug.AddCard(99785935,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's)
+local eq_0=Debug.AddCard(47529357,1,1,LOCATION_SZONE,3,POS_FACEUP)
+Debug.AddCard(504700052,1,1,LOCATION_SZONE,2,POS_FACEDOWN)
+
+Debug.ReloadFieldEnd()
+
+--Equip Function
+local function Equip(c,target)
+	Debug.PreEquip(c,target)
+	local ctype=c:Type()
+	if ctype&TYPE_EQUIP==0 then
+		local code=EFFECT_CHANGE_TYPE
+		local value=TYPE_EQUIP+TYPE_SPELL
+		if c:IsType(TYPE_TRAP) then
+			code=EFFECT_ADD_TYPE
+			value=TYPE_EQUIP
+		elseif ctype&TYPE_UNION~=0 then
+			value=value+TYPE_UNION
+		elseif ctype&TYPE_TOKEN~=0 then
+			value=value+TYPE_TOKEN
+		end
+		local eff=Effect.CreateEffect(c)
+		eff:SetType(EFFECT_TYPE_SINGLE)
+		eff:SetCode(code)
+		eff:SetValue(value)
+		eff:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		eff:SetReset(RESET_EVENT+0x17e0000)
+		c:RegisterEffect(eff,true)
+	end
+end
+
+--Equipped Cards
+Equip(eq_0,m_1)
+
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Normal Summon Mystic Tomato.
+-Activate Book of Moon, selecting Armored Zombie.
+-Activate Book of Taiyou, selecting Armored Zombie.
+-Enter the Battle Phase.
+-Attack Alpha The Magnet Warrior with Mystic Tomato. Both are destroyed.
+Use the effect of Mystic Tomato to Special Summon Mataza the Zapper.
+-Activate Rush Recklessly, selecting Mataza the Zapper.
+-Attack Armored Zombie with Mataza the Zapper.
+-Attack directly with Mataza the Zapper.
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I03_Perfect_Defense.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I03_Perfect_Defense.lua
@@ -1,0 +1,63 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 900
+Opponent's Starting LP: 4500
+Complexity: 4+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,900,0,0)
+Debug.SetPlayerInfo(1,4500,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(70781052,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(31036355,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(4929256,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(60229110,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(9720537,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(45986603,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(98045062,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(4041838,0,0,LOCATION_MZONE,2,POS_FACEDOWN_DEFENSE,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(32919136,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(99517131,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(31305911,1,1,LOCATION_MZONE,4,POS_FACEDOWN_DEFENSE,true)
+Debug.AddCard(31305911,1,1,LOCATION_MZONE,3,POS_FACEDOWN_DEFENSE,true)
+Debug.AddCard(31305911,1,1,LOCATION_MZONE,2,POS_FACEDOWN_DEFENSE,true)
+Debug.AddCard(23205979,1,1,LOCATION_MZONE,1,POS_FACEDOWN_DEFENSE,true)
+Debug.AddCard(23205979,1,1,LOCATION_MZONE,0,POS_FACEDOWN_DEFENSE,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Switch Ninja Grandmaster Sasuke in attack mode.
+-Activate Creature Swap to switch Ninja Grandmaster Sasuke with Marshmallon.
+-Sacrifice Marshmallon to tribute summon Granmarg the Rock Monarch.
+-Destroy either remaining Marshmallon with Granmarg's special ability.
+-Activate The Spell Absorbing Life. (2900 / 4500)
+-Activate Falling Down and target either Spirit Reaper.
+-Activate Enemy Controller to switch the position of remaining Spirit Reaper.
+-Activate Owner's Seal
+-Activate Snatch Steal and target Marshmallon then switch it into attack mode.
+-Attack with all remaining monsters for game. (2900 / 0)
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I04_Go_Vehicroid.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I04_Go_Vehicroid.lua
@@ -1,0 +1,55 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 6000
+Opponent's Starting LP: 5200
+Complexity: 2+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,6000,0,0)
+Debug.SetPlayerInfo(1,5200,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(48766543,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(18325492,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(50684552,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(19613556,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(69196160,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(23995346,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(504700037,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(15150365,1,1,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Set Wonder Garage.
+-Tribute Blue-Eyes Ultimate Dragon to Summon Cyber-Tech Alligator.
+-Activate Limiter Removal.
+-Activate Heavy Storm to destroy your Wonder Garage. Use Wonder Garage's effect to Summon Gyroid.
+-Enter the Battle Phase.
+-Destroy White Magical Hat with Gyroid.
+-Attack directly with Cyber-Tech Alligator.
+-Enter Main Phase 2.
+-Activate Thunder Crash.
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I05_Home_of_the_Fiends.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I05_Home_of_the_Fiends.lua
@@ -1,0 +1,59 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1000
+Opponent's Starting LP: 2400
+Complexity: 2+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,5)
+Debug.SetPlayerInfo(0,1000,0,0)
+Debug.SetPlayerInfo(1,2400,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(70368879,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(47453433,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(74848038,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(30090452,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(16226796,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(102380,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--GY (yours)
+Debug.AddCard(31829185,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Monster Zones (yours)
+Debug.AddCard(97590747,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(4178474,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(504700159,1,1,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+Debug.AddCard(504700159,1,1,LOCATION_MZONE,3,POS_FACEUP_DEFENSE,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Tribute La Jinn the Mystical Genie of the Lamp to summon Zanki.
+-Activate Raigeki Break. Discard Night Assailant to destroy Dark Jeroid.
+-Activate Back to Square One. Discard Lava Golem to return Dark Jeroid to the opponent's deck.
+-Use Monster Reincarnation. Discard Upstart Goblin to return Dark Necrofear to your hand.
+-Remove La Jinn the Mystical Genie of the Lamp, Night Assailant and Lava Golem from play to 
+Special Summon Dark Necrofear.
+-Enter the Battle Phase.
+-Attack directly with Zanki and Dark Necrofear.
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I06_Steel_Stronghold.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I06_Steel_Stronghold.lua
@@ -1,0 +1,56 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1500
+Opponent's Starting LP: 1400
+Complexity: 5/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,8500,0,0)
+Debug.SetPlayerInfo(1,8000,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(504700068,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(47529357,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(21900719,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(55713623,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(79759861,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(504700106,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(77622396,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(70095154,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(70095154,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+Debug.AddCard(83104731,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Mistobody (Mist Body) and target Relinquished.
+-Activate Twin Swords of Flashing Light - Tryce.
+-Discard Tribute to the Doomed and target Relinquished.
+-Absorb either Cyber Dragon with Relinquished.
+-Activate Shrink and target Relinquished.
+-Activate Axe of Despair and target Ancient Gear Golem. (8500 / 8000)
+-Attack Ancient Gear Golem with Relinquished. (4500 / 4000)
+-Attack Ancient Gear Golem once more with Relinquished for game. (500 / 0)
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I07_Release_the_Seal.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I07_Release_the_Seal.lua
@@ -1,0 +1,69 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 4200
+Opponent's Starting LP: 4800
+Complexity: 3/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,4200,0,0)
+Debug.SetPlayerInfo(1,4800,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(33396948,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(51632798,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(38699854,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--GY (yours)
+Debug.AddCard(8124921,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(44519536,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(70903634,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(7902349,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Monster Zones (yours)
+Debug.AddCard(504700163,0,0,LOCATION_MZONE,2,POS_FACEDOWN_DEFENSE,true)
+Debug.AddCard(31560081,0,0,LOCATION_MZONE,3,POS_FACEDOWN_DEFENSE,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(5758500,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+Debug.AddCard(4178474,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(23557835,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(70903634,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(61528025,1,1,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+Debug.AddCard(7902349,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's)
+Debug.AddCard(29549364,1,1,LOCATION_SZONE,3,POS_FACEUP)
+Debug.AddCard(33950246,1,1,LOCATION_SZONE,2,POS_FACEUP)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Raigeki Break.
+-Discard Fusilier to destroy Royal Command.
+-Flip summon Penguin Soldier.
+-Return Banisher and either Exodia piece to opponent's hand.
+-Normal summon Exodia the Forbidden One & flip summon Magician of Faith.
+-Activate Soul Release to remove any Exodia piece in your graveyard from play. (4200 / 4800)
+-Activate Dimension Fusion. (2200 / 4800)
+-Special Summon Fusilier Dragon, the Dual-Mode Beast and Exodia Piece. (2200 / 4800)
+-Attack opponent's Exodia piece with your own Exodia piece. (2200 / 4800)
+-Attack with all remaining monsters for game. (2200 / 0)
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I08_Warm_Up.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I08_Warm_Up.lua
@@ -1,0 +1,96 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 3000
+Opponent's Starting LP: 10500
+Complexity: 3+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,3000,0,0)
+Debug.SetPlayerInfo(1,10500,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(25880422,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(82828051,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(51482758,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(31036355,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(51632798,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+local m_4=Debug.AddCard(39168895,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+local m_5=Debug.AddCard(39168895,0,0,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+Debug.AddCard(13944422,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+local eq_0=Debug.AddCard(65169794,0,0,LOCATION_SZONE,4,POS_FACEUP)
+local eq_2=Debug.AddCard(65169794,0,0,LOCATION_SZONE,3,POS_FACEUP)
+Debug.AddCard(68400115,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(82732705,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(21175632,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's)
+local eq_1=Debug.AddCard(45986603,1,1,LOCATION_SZONE,3,POS_FACEUP)
+local eq_3=Debug.AddCard(45986603,1,1,LOCATION_SZONE,2,POS_FACEUP)
+
+Debug.ReloadFieldEnd()
+
+--Equip Function
+local function Equip(c,target)
+	Debug.PreEquip(c,target)
+	local ctype=c:Type()
+	if ctype&TYPE_EQUIP==0 then
+		local code=EFFECT_CHANGE_TYPE
+		local value=TYPE_EQUIP+TYPE_SPELL
+		if c:IsType(TYPE_TRAP) then
+			code=EFFECT_ADD_TYPE
+			value=TYPE_EQUIP
+		elseif ctype&TYPE_UNION~=0 then
+			value=value+TYPE_UNION
+		elseif ctype&TYPE_TOKEN~=0 then
+			value=value+TYPE_TOKEN
+		end
+		local eff=Effect.CreateEffect(c)
+		eff:SetType(EFFECT_TYPE_SINGLE)
+		eff:SetCode(code)
+		eff:SetValue(value)
+		eff:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		eff:SetReset(RESET_EVENT+0x17e0000)
+		c:RegisterEffect(eff,true)
+	end
+end
+
+--Equipped Cards
+Equip(eq_0,m_4)
+Equip(eq_1,m_4)
+Equip(eq_2,m_5)
+Equip(eq_3,m_5)
+
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Normal summon Fusilier Dragon, the Dual-Mode Beast from your hand to the field.
+-Activate The Emperor's Holiday, then activate Creature Swap.
+-Target either Berserk Gorilla to swap for St. Joan.
+-Activate Block Attack and target swapped Berserk Gorilla. (3000 / 10000)
+-Activate Skill Drain. (2000 / 10000)
+-Attack with all remaining monsters. (2000 / 500)
+-Switch to Main Phase II.
+-Activate Remove Trap and target Skill Drain. (2000 / 500)
+-Activate Earthquake for game. (2000 / 0)
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I09_Unexpected_Outcome.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I09_Unexpected_Outcome.lua
@@ -1,0 +1,52 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1000
+Opponent's Starting LP: 3700
+Complexity: 2/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1000,0,0)
+Debug.SetPlayerInfo(1,3700,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(31036355,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(79759861,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(102380,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(94004268,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(47606319,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(504700182,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(27174286,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(13039848,1,1,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+Debug.AddCard(13039848,1,1,LOCATION_MZONE,3,POS_FACEUP_DEFENSE,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Special Summon Lava Golem by sacrificing both Giant Soldier of Stone.
+-Activate Tribute to the Doomed.
+-Discard Gearfried the Iron Knight to target and destroy Lava Golem.
+-Special Summon Gigantes by removing Gearfried from play in your graveyard.
+-Activate Return from the Different Dimension. (500 / 3700)
+-Special Summon Gearfried the Iron Knight. (500 / 3700)
+-Attack with both remaining monsters for game. (500 / 0)
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I10_Smash_Open_the_Gate.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I10_Smash_Open_the_Gate.lua
@@ -1,0 +1,59 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1000
+Opponent's Starting LP: 1400
+Complexity: 2/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1000,0,0)
+Debug.SetPlayerInfo(1,1400,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(14087893,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(22537443,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(2792265,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(32809211,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(31560081,0,0,LOCATION_MZONE,2,POS_FACEDOWN_DEFENSE,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(4178474,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+Debug.AddCard(99517131,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(511000824,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+Debug.AddCard(511002996,0,0,LOCATION_SZONE,4,POS_FACEUP)
+
+--Monster Zones (opponent's)
+Debug.AddCard(89631142,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(77585513,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's)
+Debug.AddCard(85742772,1,1,LOCATION_SZONE,3,POS_FACEUP)
+Debug.AddCard(72302403,1,1,LOCATION_SZONE,2,POS_FACEUP)
+Debug.AddCard(40633297,1,1,LOCATION_SZONE,1,POS_FACEUP)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Book of Moon and target Jinzo.
+-Normal Summon Servant of Catabolism.
+-Attack directly with Servant of Catabolism. (1000 / 700)
+-Activate Ring of Destruction. (1000 / 700)
+-Target Servant of Catabolism for game. (300 / 0)
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I11_Mighty_Knights2.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I11_Mighty_Knights2.lua
@@ -1,0 +1,59 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1500
+Opponent's Starting LP: 2000
+Complexity: 3/10
+
+Objective: Win this Turn
+
+
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1500,0,0)
+Debug.SetPlayerInfo(1,2000,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(64752646,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(64306248,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(64306248,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(13944422,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(79759861,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(36354008,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(511003023,0,0,LOCATION_SZONE,2,POS_FACEUP)
+
+--Monster Zones (opponent's)
+Debug.AddCard(504700126,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(1995985,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+Debug.AddCard(64306248,1,1,LOCATION_MZONE,2,POS_FACEDOWN_DEFENSE,true)
+
+--Spell & Trap Zones (opponent's) partially written by PryQ
+local t_1=Debug.AddCard(56120475,1,1,LOCATION_SZONE,2,POS_FACEDOWN)
+t_1:GetActivateEffect():SetCondition(function() return Duel.GetAttacker() and Duel.GetAttacker():IsAttackAbove(2500) end)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Normal Summon Fire Princess from your hand to the field. (1500 / 2000)
+-Activate Ultimate Offering and summon Granadora. (2000 / 2000)
+-Chain it to Ultimate Offering and summon Skull-Mark Ladybug. (1500 / 1500)
+-Activate Ultimate Offering and summon Skull-Mark Ladybug. (1000 / 1500)
+-Activate Ultimate Offering once more. (500 / 1500)
+-Sacrifice both Skull-Mark Ladybugs to summon Gilford the Lightning.
+-Attack Silent Swordsman LV3 with Granadora for game. (2500 / 0)
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I12_Cyber_Crisis.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I12_Cyber_Crisis.lua
@@ -1,0 +1,93 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 100
+Opponent's Starting LP: 6500
+Complexity: 5/10
+
+Objective: Win this Turn
+]]
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,100,0,0)
+Debug.SetPlayerInfo(1,6500,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Main Deck (yours)
+Debug.AddCard(3019642,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+
+--Extra Deck (yours)
+Debug.AddCard(40418351,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)
+
+--Hand (yours)
+Debug.AddCard(74848038,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(70278545,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(79759861,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(41230939,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(67371383,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(17658803,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(504700068,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+local m_1=Debug.AddCard(89631142,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(77625948,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(3659803,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(511002997,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+
+--Spell & Trap Zones (opponent's)
+local eq_0=Debug.AddCard(45986603,1,1,LOCATION_SZONE,2,POS_FACEUP)
+
+Debug.ReloadFieldEnd()
+
+--Equip Function
+local function Equip(c,target)
+	Debug.PreEquip(c,target)
+	local ctype=c:Type()
+	if ctype&TYPE_EQUIP==0 then
+		local code=EFFECT_CHANGE_TYPE
+		local value=TYPE_EQUIP+TYPE_SPELL
+		if c:IsType(TYPE_TRAP) then
+			code=EFFECT_ADD_TYPE
+			value=TYPE_EQUIP
+		elseif ctype&TYPE_UNION~=0 then
+			value=value+TYPE_UNION
+		elseif ctype&TYPE_TOKEN~=0 then
+			value=value+TYPE_TOKEN
+		end
+		local eff=Effect.CreateEffect(c)
+		eff:SetType(EFFECT_TYPE_SINGLE)
+		eff:SetCode(code)
+		eff:SetValue(value)
+		eff:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		eff:SetReset(RESET_EVENT+0x17e0000)
+		c:RegisterEffect(eff,true)
+	end
+end
+
+--Equipped Cards
+Equip(eq_0,m_1)
+
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Sacrifice Cyberdark Edge to summon Amphibian Beast.
+-Activate Monster Reincarnation. Discard Luster Dragon 2 to add Cyberdark Edge to your hand.
+-Activate Tribute to the Doomed. Discard Axe of Despair to destroy Blue-Eyes White Dragon.
+-Activate Pot of Generosity, selecting Cyberdark Horn and Cyberdark Edge.
+-Activate Future Fusion, selecting Cyberdark Horn, Cyberdark Edge and Cyberdark Keel.
+-Activate Overload Fusion. Remove Cyberdark Horn, Cyberdark Edge and Cyberdark Keel from play to summon Cyberdark Dragon.
+-Activate Cyberdark Dragon's effect, equipping it with Blue-Eyes White Dragon.
+-Enter the Battle Phase.
+-Attack directly with Amphibian Beast and Cyberdark Dragon.
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I13_Level_Up.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I13_Level_Up.lua
@@ -1,0 +1,66 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1000
+Opponent's Starting LP: 1800
+Complexity: 4+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1000,0,0)
+Debug.SetPlayerInfo(1,1800,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(49140998,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(49140998,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(61850482,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(504700046,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(504700046,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(70368879,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--GY (yours)
+Debug.AddCard(504700075,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(73879377,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(59464593,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Monster Zones (yours)
+Debug.AddCard(34853266,0,0,LOCATION_MZONE,3,POS_FACEDOWN_DEFENSE,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(70828912,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+
+--Main Deck (opponent's)
+Debug.AddCard(40640057,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(40640057,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(84636823,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Flip summon Tsukuyomi, using its effect to flip Spell Canceller face down.
+-Activate Premature Burial, summoning Armed Dragon LV5.
+-Activate A Feather of the Phoenix. Discard Level Modulation to add Armed Dragon LV7 to your deck.
+-Activate Level Up!, tributing Armed Dragon LV5 to summon Armed Dragon LV7.
+-Activate A Feather of the Phoenix. Discard Level Up! to add Armed Dragon LV5 to your deck.
+-Activate Upstart Goblin. You draw Armed Dragon LV5.
+-Tribute Tsukuyomi to summon Armed Dragon LV5.
+-Enter the Battle Phase.
+-Attack Spell Canceller with Armed Dragon LV5.
+-Attack directly with Armed Dragon LV7.
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I14_Path_of_Warriors.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I14_Path_of_Warriors.lua
@@ -1,0 +1,67 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 2500
+Opponent's Starting LP: 8100
+Complexity: 4/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,2500,0,0)
+Debug.SetPlayerInfo(1,8100,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Main Deck (yours)
+Debug.AddCard(1184620,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(1184620,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+
+--Hand (yours)
+Debug.AddCard(2460565,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(1184620,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(39719977,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(31036355,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(25774450,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(4335645,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(511000824,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+Debug.AddCard(12247206,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(65830223,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+
+--Main Deck (opponent's)
+Debug.AddCard(70781052,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(70781052,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+Debug.AddCard(70781052,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(73216412,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Coffin Seller then Ring of Destruction.
+-Target and destroy your opponent's Worm Drake. (1100 / 6400)
+-Activate Creature Swap to exchange Newdoria for either of the Summoned Skull.
+-Normal Summon Marauding Captain from your hand to the field.
+-Special Summon Kojikocy and activate Inferno Reckless Summon.
+-Activate Delta Attacker, then attack directly with all copies of Kojikocy.
+-Attack Newdoria with Summoned Skull. (1100 / 600)
+-Destroy either opponent's Summoned Skull with Newdoria's Special Ability.
+-Switch to Main Phase 2 and activate Mystic Box. (1100 / 300)
+-Destroy your opponent's remaining Summoned Skull for game. (1100 / 0)
+]]

--- a/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I15_Unlimited_Fusion_Power.lua
+++ b/GX Spirit Caller/2_Intermediate/[GX_Spirit_Caller]I15_Unlimited_Fusion_Power.lua
@@ -1,0 +1,74 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 8000
+Opponent's Starting LP: 8000
+Complexity: 2/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,8000,0,0)
+Debug.SetPlayerInfo(1,8000,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Extra Deck (yours)
+Debug.AddCard(10248389,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)
+Debug.AddCard(10248389,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)
+Debug.AddCard(35809262,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)
+Debug.AddCard(35809262,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)
+
+--Hand (yours)
+Debug.AddCard(23557835,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(18511384,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(45906428,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(24094653,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Banished (yours)
+Debug.AddCard(21844576,0,0,LOCATION_REMOVED,0,POS_FACEUP)
+Debug.AddCard(58932615,0,0,LOCATION_REMOVED,0,POS_FACEUP)
+Debug.AddCard(97023549,0,0,LOCATION_REMOVED,0,POS_FACEUP)
+Debug.AddCard(11460577,0,0,LOCATION_REMOVED,0,POS_FACEUP)
+
+--Banished (opponent's)
+Debug.AddCard(38033123,1,1,LOCATION_REMOVED,0,POS_FACEUP)
+Debug.AddCard(38033123,1,1,LOCATION_REMOVED,0,POS_FACEUP)
+Debug.AddCard(38033123,1,1,LOCATION_REMOVED,0,POS_FACEUP)
+
+--AI summon Dark Magician Girl in ATK Pos (written by edo9300)
+local e2=Effect.GlobalEffect()
+    e2:SetType(EFFECT_TYPE_FIELD)
+    e2:SetCode(EFFECT_FORCE_SPSUMMON_POSITION)
+    e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+    e2:SetTargetRange(0,1)
+    e2:SetValue(POS_FACEUP_ATTACK)
+    Duel.RegisterEffect(e2,0)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Dimension Fusion. You summon Elemental Hero Avian, Elemental Hero Burstinatrix, Blade Skater and 
+Etoile Cyber. Your opponent summons 3 Dark Magician Girl
+-Activate Polymerization. Fuse Etoile Cyber and Blade Skater to create Cyber Blader.
+-Activate Fusion Recovery. Select Etoile Cyber.
+-Summon Etoile Cyber in attack mode.
+-Activate Polymerization. Fuse Elemental Hero Avian and Elemental Hero Burstinatrix to create Elemental Hero Flame Wingman.
+-Activate Miracle Fusion. Remove Elemental Hero Avian and Elemental Hero Burstinatrix to create Elemental Hero Flame Wingman.
+-Enter the Battle Phase.
+-Attack Dark Magician Girl with Elemental Hero Flame Wingman.
+-Attack the 2nd Dark Magician Girl with Cyber Blader.
+-Attack the 3rd Dark Magician Girl with Elemental Hero Flame Wingman.
+-Attack directly with Etoile Cyber.
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A01_Underdog_Power.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A01_Underdog_Power.lua
@@ -1,0 +1,68 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1000
+Opponent's Starting LP: 5000
+Complexity: 4/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1000,0,0)
+Debug.SetPlayerInfo(1,5000,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(14181608,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(89091579,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(62337487,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(77454922,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--GY (yours)
+Debug.AddCard(89091579,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(32274490,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(92667214,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(20277860,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(30531525,0,0,LOCATION_SZONE,0,POS_FACEDOWN)
+Debug.AddCard(5703682,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+Debug.AddCard(36280194,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(39019325,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+Debug.AddCard(44182827,0,0,LOCATION_SZONE,4,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(31829185,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(31829185,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's)
+Debug.AddCard(84970821,1,1,LOCATION_SZONE,3,POS_FACEUP)
+Debug.AddCard(504700141,1,1,LOCATION_SZONE,2,POS_FACEUP)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Summon Mushroom Man
+-Activate Order to Smash with sacrificing the Mushroom Man, choose opponent's Toll and 
+Curse of Darkness to destroy both of it.
+-Activate Backup Soldier and choose Basic Insect, Mushroom Man and Clown Zombie to bring them to your hand.
+-Activate Samsara in the field.
+-Activate Fortress Whale's Oath in your hand then sacrifice all other monster cards in your hand (4 Cards). 
+-Choose to summon Fortress Whale in attack mode.
+-Activate Enchanting Fitting Room, choose all special summon monster in attack mode.
+-Activate Thousand Energy.
+-Attack with Clown Zombie and Fortress Whale to destroy all opponent's Dark Necrofear.
+-Attack directly with the remaining monsters for game.
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A02_No_Way.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A02_No_Way.lua
@@ -1,0 +1,117 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 3100
+Opponent's Starting LP: 15200
+Complexity: 3+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,3100,0,0)
+Debug.SetPlayerInfo(1,15200,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(504700030,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(14391920,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(504700068,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(66362965,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(58071123,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(504700159,0,0,LOCATION_MZONE,3,POS_FACEDOWN_DEFENSE,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(40633297,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+
+
+--Main Deck (opponent's)
+Debug.AddCard(89631142,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(87796900,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(14181608,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(87564352,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(89631142,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(89631142,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(13069066,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(6285791,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(15025844,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(32274490,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(5053103,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(69669405,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(76184692,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(15025844,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(76184692,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(76184692,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(32452818,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(88819587,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(41392891,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(88819587,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(68846917,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(35762283,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(41392891,1,1,LOCATION_DECK,0,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(31305911,1,1,LOCATION_MZONE,4,POS_FACEDOWN_DEFENSE,true)
+local m_1=Debug.AddCard(14181608,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(31812496,1,1,LOCATION_MZONE,2,POS_FACEDOWN_DEFENSE,true)
+Debug.AddCard(27125110,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's)
+Debug.AddCard(68073522,1,1,LOCATION_SZONE,2,POS_FACEUP)
+local eq_0=Debug.AddCard(47529357,1,1,LOCATION_SZONE,3,POS_FACEUP)
+
+Debug.ReloadFieldEnd()
+
+--Equip Function
+local function Equip(c,target)
+	Debug.PreEquip(c,target)
+	local ctype=c:Type()
+	if ctype&TYPE_EQUIP==0 then
+		local code=EFFECT_CHANGE_TYPE
+		local value=TYPE_EQUIP+TYPE_SPELL
+		if c:IsType(TYPE_TRAP) then
+			code=EFFECT_ADD_TYPE
+			value=TYPE_EQUIP
+		elseif ctype&TYPE_UNION~=0 then
+			value=value+TYPE_UNION
+		elseif ctype&TYPE_TOKEN~=0 then
+			value=value+TYPE_TOKEN
+		end
+		local eff=Effect.CreateEffect(c)
+		eff:SetType(EFFECT_TYPE_SINGLE)
+		eff:SetCode(code)
+		eff:SetValue(value)
+		eff:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		eff:SetReset(RESET_EVENT+0x17e0000)
+		c:RegisterEffect(eff,true)
+	end
+end
+
+--Equipped Cards
+Equip(eq_0,m_1)
+
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Bad Reaction to Simochi and flip summon Dark Jeroid.
+-Designate Oxygeddon as the target to deduct 800 attack points.
+-Tribute summon The Fiend Megacyber from your hand in attack mode.
+-Sacrifice Dark Jeroid in order to do so.
+-Activate Ring of Magnetism and designate Oxygeddon as the target.
+-Activate Axe of Despair and designate The Fiend Megacyber as the target.
+-Attack Thousand-Eyes Idol with The Fiend Megacyber. (3100 / 12000)
+-Attack Stone Statue of the Aztecs with Oxygeddon. (100 / 12000)
+-Activate Inferno Tempest for game. (100 / 0)
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A03_Sharp_Strategy.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A03_Sharp_Strategy.lua
@@ -1,0 +1,68 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 100
+Opponent's Starting LP: 7400
+Complexity: 4+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,100,0,0)
+Debug.SetPlayerInfo(1,7400,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(69162969,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(16226796,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(38699854,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(511003009,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(40659562,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(51481927,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--GY (yours)
+Debug.AddCard(504700136,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Monster Zones (yours)
+Debug.AddCard(504700163,0,0,LOCATION_MZONE,3,POS_FACEDOWN_DEFENSE,true)
+Debug.AddCard(15341822,0,0,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+Debug.AddCard(15341823,0,0,LOCATION_MZONE,1,POS_FACEUP_DEFENSE,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(53582587,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+Debug.AddCard(511003023,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(65830223,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(31305911,1,1,LOCATION_MZONE,3,POS_FACEDOWN_DEFENSE,true)
+Debug.AddCard(504700075,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(504700015,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Coffin Seller then Spell Absorption.
+-Flip Summon Penguin Soldier.
+-Return Horus Lvl. 6 & Marshmallon to your opponent's hand.
+-Chain it to Ultimate Offering then activate Lightning Vortex. (100 / 7400)
+-Discard Night Assailant, then select Slate Warrior from the graveyard.
+Set Slate Warrior face down from your hand to the field. (600 / 7100)
+-Activate Book of Taiyou to target Slate Warrior. (1100 / 7100)
+-Chain special ability to Ultimate Offering and activate it. (600 / 7100)
+-Sacrifice both Fluffy Tokens in order to tribute summon Ultimate Tyranno.
+-Activate Ultimate Offering once more. (100 / 7100)
+-Sacrifice Penguin Soldier to tribute summon Guardian Sphinx in attack mode.
+-Attack with all monsters for game. (100 / 7100)
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A04_Your_Challenge3.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A04_Your_Challenge3.lua
@@ -1,0 +1,57 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 1600
+Opponent's Starting LP: 3400
+Complexity: 5/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,1600,0,0)
+Debug.SetPlayerInfo(1,3400,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(75560629,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(22537443,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(504700138,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(11384280,0,0,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+Debug.AddCard(504700106,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(27618634,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(27618634,0,0,LOCATION_MZONE,4,POS_FACEUP_ATTACK,true)
+
+--Monster Zones (opponent's)
+Debug.AddCard(23205979,1,1,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+Debug.AddCard(31305911,1,1,LOCATION_MZONE,1,POS_FACEUP_DEFENSE,true)
+Debug.AddCard(13945283,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(504700042,1,1,LOCATION_MZONE,4,POS_FACEUP_DEFENSE,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Flint and designate Spirit Reaper as the target.
+-Equip Wall of Illusion with Flint from the graveyard.
+-Absorb Marshmallon with Relinquished.
+-Attack Wall of Illusion with Cannon Soldier. (1600 / 2700)
+-Equip A Cat of Ill Omen with Flint.
+-Attack A Cat of Ill Omen with either The Unhappy Girl.
+-Equip the attacking The Unhappy Girl with Flint afterwards.
+-Attack with Relinquished & remaining The Unhappy Girl. (1600 / 2000)
+-Normal Summon Cannon Soldier, then activate its special ability.
+-Sacrifice all monsters for game. (1600 /0)
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A05_Performance_Testing.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A05_Performance_Testing.lua
@@ -1,0 +1,62 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 100
+Opponent's Starting LP: 8500
+Complexity: 3+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,100,0,0)
+Debug.SetPlayerInfo(1,8500,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Main Deck (yours)
+Debug.AddCard(51945556,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(79759861,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+
+--Hand (yours)
+Debug.AddCard(34187685,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(504700053,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(5318639,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(504700118,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(83968380,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+Debug.AddCard(53046408,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(98444741,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+Debug.AddCard(5728014,0,0,LOCATION_SZONE,4,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(60246171,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(57062206,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Mystical Space Typhoon. Target Jar of Greed.
+-Chain A Rival Appears!. Designate Daitsu as target, then chain it to Emergency Provisions.
+-Designate Jar of Greed, A Rival Appears! and Mystical Space Typhoon as targets.
+-Chain it to Accumulated Fortune. (3100 / 8500)
+-Special Summon Element Dragon to the field in attack mode.
+-Activate Double Attack.
+-Discard Zaborg the Thunder Monarch and target Element Dragon.
+-Attack Soitsu with Black Luster Soldier - Envoy of the Beginning. (2100 / 5500)
+-Attack Doitsu with Black Luster Soldier - Envoy of the Beginning. (2100 / 2600)
+-Attack twice with Element Dragon for game. (2100 / 0)
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A06_Token_Master.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A06_Token_Master.lua
@@ -1,0 +1,63 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 2000
+Opponent's Starting LP: 5200
+Complexity: 5/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,2000,0,0)
+Debug.SetPlayerInfo(1,5200,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(11384280,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(4041838,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(504700075,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(511000228,0,0,LOCATION_MZONE,4,POS_FACEUP_ATTACK,true)
+Debug.AddCard(15341821,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(15341821,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(15341821,0,0,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(83675475,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+Debug.AddCard(29843091,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(15303296,1,1,LOCATION_MZONE,4,POS_FACEUP_ATTACK,true)
+Debug.AddCard(14181608,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(14181608,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(14181608,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+Debug.AddCard(61528025,1,1,LOCATION_MZONE,0,POS_FACEUP_DEFENSE,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Sacrifice any Dandylion to tribute summon Armed Dragon LV5 in attack mode.
+-Attack Banisher of the Light with Armed Dragon LV5.
+-Attack any Mushroom Man with Catapult Turtle. (2000 / 5000)
+-Switch to Main Phase II and activate Armed Dragon LV5's special ability.
+-Discard either monster from your hand to the graveyard.
+-Destroy any monster on your opponent's field.
+-Activate Ojama Trio then Catapult Turtle's special ability.
+-Sacrifce either Dandylion & Armed Dragon LV5. (2000 / 3650)
+-Activate Catapult Turtle and sacrifice the last Dandylion. (2000 / 3500)
+-Activate Token Feastevil then Catapult Turtle's special ability. (2000 / 500)
+-Sacrifice Catapult Turtle itself for game. (2000 / 0)
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A07_Ninja_Squad_Arrives.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A07_Ninja_Squad_Arrives.lua
@@ -1,0 +1,65 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 5000
+Opponent's Starting LP: 5200
+Complexity: 6/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,5000,0,0)
+Debug.SetPlayerInfo(1,5200,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(16222645,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(9373534,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(43434803,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(38699854,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(242146,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(4041838,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--GY (yours)
+Debug.AddCard(9076207,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(14618326,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Monster Zones (yours)
+Debug.AddCard(41006930,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(31560081,0,0,LOCATION_MZONE,3,POS_FACEDOWN_DEFENSE,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(97342942,0,0,LOCATION_SZONE,2,POS_FACEUP)
+
+--Monster Zones (opponent's)
+Debug.AddCard(78658564,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(504700038,1,1,LOCATION_MZONE,3,POS_FACEUP_DEFENSE,true)
+
+--Spell & Trap Zones (opponent's)
+Debug.AddCard(4206964,1,1,LOCATION_SZONE,2,POS_FACEDOWN)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Ballista of Rampart Smashing on Spirit Reaper.
+-Summon Ninja Grandmaster Sasuke.
+-The Shallow Grave, select Ninja Grandmaster Sasuke.
+-Use Book of Taiyou on a monster set by The Shallow Grave.
+-Flip Magician of Faith and select Book of Taiyou.
+-Use Book of Taiyou on the last face down monster.
+-Fuhma on Ninja Grandmaster Sasuke.
+-Attack Spirit Reaper with the 2 ninja's.
+-Tribute Ninja Grandmaster Sasuke (Ectoplasmer).
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A08_Walk_the_Tightrope.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A08_Walk_the_Tightrope.lua
@@ -1,0 +1,65 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 500
+Opponent's Starting LP: 4000
+Complexity: 5+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,500,0,0)
+Debug.SetPlayerInfo(1,4000,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(70278545,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(86445415,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(97590747,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(13839120,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(41172955,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(504700159,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(41172955,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(86445415,0,0,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(93382620,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+Debug.AddCard(93382620,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(93382620,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+Debug.AddCard(33248692,0,0,LOCATION_SZONE,4,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(504700038,1,1,LOCATION_MZONE,3,POS_FACEUP_DEFENSE,true)
+Debug.AddCard(30113682,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(76812113,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Summon La Jinn the Mystical Genie of the Lamp.
+-Activate Pot of Generosity, choose Red and Yellow Gadgets.
+-Battle Phase, attack Judge Man with La Jinn.
+-Activate Option Hunter.
+-Attack Harpie Lady with Red Gadget.
+-Activate Rope of Life, then Red Gadget's effect.
+-Attack Judge Man with Green Gadget.
+-Activate Rope of Life, then Green Gadget's effect.
+-Attack Judge Man with Dark Jeroid.
+-Activate Rope of Life, target Spirit Reaper with Dark Jeroid's effect.
+-Attack Judge Man with Green Gadget.
+-Attack with Red Gadget and Dark Jeroid for the win.
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A09_Horus_Weakness.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A09_Horus_Weakness.lua
@@ -1,0 +1,81 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 5000
+Opponent's Starting LP: 5500
+Complexity: 7+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,5000,0,0)
+Debug.SetPlayerInfo(1,5500,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Main Deck (yours)
+Debug.AddCard(49791927,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(49791927,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(97169186,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(47606319,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(87796900,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+
+--Hand (yours)
+Debug.AddCard(74131780,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(98494543,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(504700071,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--GY (yours)
+Debug.AddCard(28546905,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(32452818,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(15303296,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Monster Zones (yours)
+Debug.AddCard(37043180,0,0,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+Debug.AddCard(31560081,0,0,LOCATION_MZONE,2,POS_FACEDOWN_DEFENSE,true)
+Debug.AddCard(16768387,0,0,LOCATION_MZONE,3,POS_FACEDOWN_DEFENSE,true)
+Debug.AddCard(28470714,0,0,LOCATION_MZONE,4,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(51452091,0,0,LOCATION_SZONE,4,POS_FACEDOWN)
+Debug.AddCard(4178474,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+Debug.AddCard(36280194,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(82732705,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(504700015,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(71200730,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's)
+Debug.AddCard(85742772,1,1,LOCATION_SZONE,3,POS_FACEUP)
+Debug.AddCard(34646691,1,1,LOCATION_SZONE,2,POS_FACEUP)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Raigeki Break discarding Exiled Force to destroy Stumbling.
+-Flip Summon Big Eye then switch the order of your deck to the following:
+	Smashing Ground (1), Gigantes (2), Winged Dragon, Guardian of the Fortress #1 (3), Tiger Axe (4), Tiger Axe (5).
+-Activate Monster Gate.
+-Tribute Dimensional Warrior in order to meet requirement.
+-Flip Summon Magician of Faith to return Smashing Ground to your hand.
+-Activate Smashing Ground to destroy Despair from the Dark.
+-Activate Backup Soldier.
+-Select all three cards, then activate Excavation of Mage Stones.
+-Discard Beaver Warrior & Illusionist Faceless Mage to your graveyard.
+-Select and return Smashing Ground then activate Skill Drain. (4000 / 5500)
+-Activate Smashing Ground to destroy Horus the Black Flame Dragon LV6. (4000 / 5500)
+-Normal Summon Ryu-Kishin then activate Royal Decree. (4000 / 5000)
+-Attack with all monsters for game. (4000 / 0)
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A10_Voice_from_the_Darkness.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A10_Voice_from_the_Darkness.lua
@@ -1,0 +1,61 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 5000
+Opponent's Starting LP: 5000
+Complexity: 3+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,5000,0,0)
+Debug.SetPlayerInfo(1,5000,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(303660,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(18144507,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(19613556,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(74131780,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(79759861,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(14087893,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(77585513,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(74677422,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(53582587,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+Debug.AddCard(83887306,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+Debug.AddCard(504700059,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(77585513,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(74677422,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's)
+Debug.AddCard(53582587,1,1,LOCATION_SZONE,3,POS_FACEDOWN)
+Debug.AddCard(56120475,1,1,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(83887306,1,1,LOCATION_SZONE,1,POS_FACEDOWN)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Equip Amplifier to enemy Jinzo.
+-Use Heavy Storm.
+-Summon Exiled Force and do not activate effect.
+-Use Tribute to the Doomed to destroy enemy Red Eyes Black Dragon (discard either card).
+-All monsters attack directly.
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A11_Final_Challenge.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A11_Final_Challenge.lua
@@ -1,0 +1,60 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 100
+Opponent's Starting LP: 12900
+Complexity: 4/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,100,0,0)
+Debug.SetPlayerInfo(1,12900,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(77622396,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(21593987,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(21900719,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(79759861,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(55226821,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(62180201,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+local m_1=Debug.AddCard(511000228,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(4178474,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+
+--Spell & Trap Zones (opponent's)
+local t_1=Debug.AddCard(504700050,1,1,LOCATION_SZONE,2,POS_FACEUP)
+
+Debug.ReloadFieldEnd()
+
+--Nightmare Wheel Targets
+Debug.PreSetTarget(t_1,m_1)
+
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate "Raigeki Break", discarding "Tribute to the Doomed" and selecting "Shadow Spell".
+-Set "Makyura the Destructor".
+-Tribute "Makyura the Destructor" with the effect of "Catapult Turtle".
+-Activate "Reverse Trap".
+-Activate "Twin Swords of Flashing Light - Tryce", discarding "Lightning Blade", equipping it to Dark Dreadroute".
+-Attack twice with "Dark Dreadroute".
+-Attack with "Catapult Turtle".
+-Tribute "Dark Dreadroute" with the effect of "Catapult Turtle".
+-Tribute "Catapult Turtle" with its own effect.
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A12_Worst_Enemy.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A12_Worst_Enemy.lua
@@ -1,0 +1,97 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 5700
+Opponent's Starting LP: 5600
+Complexity: 6+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,5700,0,0)
+Debug.SetPlayerInfo(1,5600,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(13215230,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(67371383,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(62180201,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(11901678,0,0,LOCATION_MZONE,0,POS_FACEUP_ATTACK,true)
+Debug.AddCard(9076207,0,0,LOCATION_MZONE,1,POS_FACEDOWN_DEFENSE,true)
+Debug.AddCard(34460851,0,0,LOCATION_MZONE,2,POS_FACEDOWN_DEFENSE,true)
+Debug.AddCard(34460851,0,0,LOCATION_MZONE,3,POS_FACEDOWN_DEFENSE,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(83133491,0,0,LOCATION_SZONE,0,POS_FACEDOWN)
+Debug.AddCard(35686188,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+Debug.AddCard(511003023,0,0,LOCATION_SZONE,2,POS_FACEUP)
+Debug.AddCard(34646691,0,0,LOCATION_SZONE,3,POS_FACEUP)
+Debug.AddCard(511000822,0,0,LOCATION_SZONE,4,POS_FACEDOWN)
+
+--Spell & Trap Zones (opponent's)
+local eq_0=Debug.AddCard(22046459,1,1,LOCATION_SZONE,2,POS_FACEUP)
+
+--Monster Zones (opponent's)
+Debug.AddCard(504700117,1,1,LOCATION_MZONE,4,POS_FACEUP_ATTACK,true)
+Debug.AddCard(504700117,1,1,LOCATION_MZONE,0,POS_FACEUP_ATTACK,true)
+Debug.AddCard(77585513,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(62180201,1,1,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+local m_1=Debug.AddCard(62180201,1,1,LOCATION_MZONE,1,POS_FACEUP_DEFENSE,true)
+
+Debug.ReloadFieldEnd()
+
+--Equip Function
+local function Equip(c,target)
+	Debug.PreEquip(c,target)
+	local ctype=c:Type()
+	if ctype&TYPE_EQUIP==0 then
+		local code=EFFECT_CHANGE_TYPE
+		local value=TYPE_EQUIP+TYPE_SPELL
+		if c:IsType(TYPE_TRAP) then
+			code=EFFECT_ADD_TYPE
+			value=TYPE_EQUIP
+		elseif ctype&TYPE_UNION~=0 then
+			value=value+TYPE_UNION
+		elseif ctype&TYPE_TOKEN~=0 then
+			value=value+TYPE_TOKEN
+		end
+		local eff=Effect.CreateEffect(c)
+		eff:SetType(EFFECT_TYPE_SINGLE)
+		eff:SetCode(code)
+		eff:SetValue(value)
+		eff:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		eff:SetReset(RESET_EVENT+0x17e0000)
+		c:RegisterEffect(eff,true)
+	end
+end
+
+--Equipped Cards
+Equip(eq_0,m_1)
+
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Normal Summon Dream Clown in attack mode to activate Stumbling.
+-Destroy Jinzo then switch Black Skull Dragon into Defense Mode.
+-Flip Summon Armed Ninja designating Megamorph as the target.
+-Activate Ultimate Offering. (5200 / 5600)
+-Sacrifice Dream Clown to tribute summon Amphibian Beast in attack mode.
+-Activate Zero Gravity, then follow up with Tragedy.
+-Activate Ultimate Offering. (4700 / 5600)
+-Sacrifice Armed Ninja and both Flame Manipulators to summon Dark Dreadroute.
+-Chain Crush Card Virus to Stumbling and tribute Dark Dreadroute.(4700 / 5600)
+-Attack with both monsters for game. (4700 / 5600)
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A13_Floating_Fluff.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A13_Floating_Fluff.lua
@@ -1,0 +1,59 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 6300
+Opponent's Starting LP: 6300
+Complexity: 4+/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,6300,0,0)
+Debug.SetPlayerInfo(1,6300,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(31036355,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(4929256,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(10012614,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(71453557,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(70095154,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(43434803,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(9817927,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(83133491,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+Debug.AddCard(79759861,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(41356846,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+
+--Monster Zones (opponent's)
+Debug.AddCard(15341821,1,1,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Tribute to the Doomed, discarding Cyber Dragon, destroy Dandylion.
+-Activate The Shallow Grave, Cyber Dragon and Dandylion return.
+-Activate Acid Trap Hole, targeting Dandylion.
+-Switch Gyaku-Gire Panda into Defense mode, then activate Zero Gravity.
+-Activate Autonomous Action Unit, returning Dandylion.
+-Activate Creature Swap, exchanging a Fluffy Token for Dandylion.
+-Tribute Summon Mobius the Frost Monarch, sacrificing Cyber Dragon.
+-Activate Mobius's effect, destroying Autonomous Action Unit.
+-Activate Banner of Courage, go to the Battle Phase.
+-Swing with the Panda, then attack the attack position tokens for lethal damage.
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A14_What_Will_Remain.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A14_What_Will_Remain.lua
@@ -1,0 +1,77 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 2000
+Opponent's Starting LP: 5500
+Complexity: 7/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,5)
+Debug.SetPlayerInfo(0,2000,0,0)
+Debug.SetPlayerInfo(1,5500,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Hand (yours)
+Debug.AddCard(13429800,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(17597059,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(38699854,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(69579761,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(45986603,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--GY (yours)
+Debug.AddCard(64306248,0,0,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Monster Zones (yours)
+Debug.AddCard(13945283,0,0,LOCATION_MZONE,2,POS_FACEUP_DEFENSE,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(43434803,0,0,LOCATION_SZONE,0,POS_FACEDOWN)
+Debug.AddCard(31036355,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+Debug.AddCard(61705417,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(15866454,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+Debug.AddCard(511003023,0,0,LOCATION_SZONE,4,POS_FACEUP)
+
+--GY (opponent's)
+Debug.AddCard(5318639,1,1,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(22702055,1,1,LOCATION_GRAVE,0,POS_FACEUP)
+Debug.AddCard(16222645,1,1,LOCATION_GRAVE,0,POS_FACEUP)
+
+--Monster Zones (opponent's)
+Debug.AddCard(61587183,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+Debug.AddCard(18318842,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (opponent's)
+Debug.AddCard(51452091,1,1,LOCATION_SZONE,3,POS_FACEUP)
+Debug.AddCard(30606547,1,1,LOCATION_SZONE,2,POS_FACEUP)
+Debug.AddCard(34646691,1,1,LOCATION_SZONE,1,POS_FACEUP)
+
+Debug.ReloadFieldEnd()
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Activate Spiritualism to target and return Royal Decree back to opponent's hand.
+-Switch Wall of Illusion in attack mode, then activate Graverobber.
+-Select Umi from your opponent's graveyard, then activate Snatch Steal.
+-Target Abyss Soldier and activate its special ability.
+-Discard Great White to target and return Stumbling back to opp. hand.
+-Activate The Shallow Grave and select Skull-Mark Ladybug from the graveyard.
+-Sacrifice Skull-Mark Ladybug to tribute summon Byser Shock in attack mode.
+-Activate Creature Swap, swapping Byser Shock for Dark Scorpion - Chick the Yellow.(3000/5500)
+-Activate Umi, then follow up with Ultimate Offering. (500 / 5500)
+-Set Des Koala and activate Book of Taiyou, targeting Des Koala. (500 / 4300)
+-Attack Byser Shock with Dark Scorpion - Chick the Yellow, then use its special ability.
+-Return The Dark Door from the field back to opponent's hand. (500 / 4100)
+-Attack with all remaining monsters for game. (500 / 0)
+]]

--- a/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A15_Tenacity_of_Blue_Eyes_White_Dragon.lua
+++ b/GX Spirit Caller/3_Advanced/[GX_Spirit_Caller]A15_Tenacity_of_Blue_Eyes_White_Dragon.lua
@@ -1,0 +1,113 @@
+--blackiskate#7879
+--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
+--[[message
+Reproduces a Duel Puzzle from "Yu-Gi-Oh! GX Spirit Caller"
+
+
+Your Starting LP: 3600
+Opponent's Starting LP: 15200
+Complexity: 8/10
+
+Objective: Win this Turn
+]]
+--Partially rewritten by edo9300
+Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,2)
+Debug.SetPlayerInfo(0,3600,0,0)
+Debug.SetPlayerInfo(1,15200,0,0)
+Debug.SetAIName("Professor Sartyr")
+
+--Main Deck (yours)
+Debug.AddCard(24094653,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(74848038,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+Debug.AddCard(89631142,0,0,LOCATION_DECK,0,POS_FACEDOWN)
+
+--Extra Deck (yours)
+Debug.AddCard(23995346,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)
+
+--Hand (yours)
+Debug.AddCard(70828912,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(69162969,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(504700026,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(89631142,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(95281259,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(55144522,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(90928333,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+Debug.AddCard(34627841,0,0,LOCATION_HAND,0,POS_FACEDOWN)
+
+--Monster Zones (yours)
+Debug.AddCard(17985575,0,0,LOCATION_MZONE,1,POS_FACEUP_ATTACK,true)
+Debug.AddCard(67724379,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(89631142,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)
+
+--Spell & Trap Zones (yours)
+Debug.AddCard(97077563,0,0,LOCATION_SZONE,0,POS_FACEDOWN)
+Debug.AddCard(5728014,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
+Debug.AddCard(34460239,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
+Debug.AddCard(504700166,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
+Debug.AddCard(511003023,0,0,LOCATION_SZONE,4,POS_FACEUP)
+
+--Monster Zones (opponent's)
+Debug.AddCard(18325492,1,1,LOCATION_MZONE,3,POS_FACEUP_DEFENSE,true)
+local m_1=Debug.AddCard(76232340,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
+Debug.AddCard(31305911,1,1,LOCATION_MZONE,1,POS_FACEUP_DEFENSE,true)
+
+--Spell & Trap Zones (opponent's)
+local eq_0=Debug.AddCard(47529357,1,1,LOCATION_SZONE,2,POS_FACEUP)
+Debug.AddCard(504700141,1,1,LOCATION_SZONE,3,POS_FACEUP)
+
+Debug.ReloadFieldEnd()
+
+--Equip Function
+local function Equip(c,target)
+	Debug.PreEquip(c,target)
+	local ctype=c:Type()
+	if ctype&TYPE_EQUIP==0 then
+		local code=EFFECT_CHANGE_TYPE
+		local value=TYPE_EQUIP+TYPE_SPELL
+		if c:IsType(TYPE_TRAP) then
+			code=EFFECT_ADD_TYPE
+			value=TYPE_EQUIP
+		elseif ctype&TYPE_UNION~=0 then
+			value=value+TYPE_UNION
+		elseif ctype&TYPE_TOKEN~=0 then
+			value=value+TYPE_TOKEN
+		end
+		local eff=Effect.CreateEffect(c)
+		eff:SetType(EFFECT_TYPE_SINGLE)
+		eff:SetCode(code)
+		eff:SetValue(value)
+		eff:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		eff:SetReset(RESET_EVENT+0x17e0000)
+		c:RegisterEffect(eff,true)
+	end
+end
+
+--Equipped Cards
+Equip(eq_0,m_1)
+
+Debug.ShowHint("Win in this turn!")
+aux.BeginPuzzle()
+
+--[[
+********
+-=-=-=-=
+Solution
+=-=-=-=-
+********
+
+-Sacrifice Lord of D. & Koumori Dragon to tribute summon Blue-Eyes White Dragon in attack mode.
+-Activate Generation Shift, selecting Blue-Eyes White Dragon.
+-Activate Pot of Greed, then activate Monster Reincarnation.
+-Discard Premature Burial and select Blue-Eyes White Dragon.
+-Activate Polymerization to fusion summon Blue-Eyes Ultimate Dragon.
+-Activate Call of the Haunted and select Blue-Eyes White Dragon.
+-Activate Dark Factory of Mass Production.
+-Select both Blue-Eyes White Dragon, then activate A Rival Appears!.
+-Select Sengenjin to summon Blue-Eyes White Dragon in attack mode.
+-Activate Lightning Vortex by discarding Burst Stream of Destruction.
+-Normal Summon Kaibaman with Ultimate Offering.
+-Activate Kaibaman special ability to special summon Blue-Eyes White Dragon from your hand.
+-Activate The Warrior Returning Alive and select Kaibaman.
+-Normal Summon Kaibaman with Ultimate Offering.
+-Activate Aqua Chorus, then Attack with all monsters. (100 / 0)
+]]


### PR DESCRIPTION
Hi everyone, I saw that there are puzzles in EDOPro from the old DS game Yu-Gi-Oh! NightmareTroubadour. So I rebuild all puzzles from Yu-Gi-Oh! GX Spirit Caller (2007),  thats the sequel to 2005's Nightmare Troubadour.
They all work perfectly (especially because of Naims, Edos and PyrQs help^^). I've added complexity-ratings and solutions for each puzzle.  45 puzzles in total. Divided into beginner, intermediate and advanced just like in the original DS game.

I thought it would be great to make it accessible to everyone. Could it be implemented ingame? (Canon collection) It would be a shame if people didn't have access to them, because they are high-quality puzzles. Is there a possibility? 
Suggestions for improvement are welcome. 
Thanks in advance.